### PR TITLE
Invokes share when file export fails

### DIFF
--- a/app.json
+++ b/app.json
@@ -39,7 +39,19 @@
           "backgroundColor": "#ffffff"
         }
       ],
-      "expo-sqlite"
+      "expo-sqlite",
+      [
+        "react-native-share",
+        {
+          "ios": ["fb", "instagram", "twitter", "tiktoksharesdk"],
+          "android": [
+            "com.facebook.katana",
+            "com.instagram.android",
+            "com.twitter.android",
+            "com.zhiliaoapp.musically"
+          ]
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.1.0",
     "react-native-select-dropdown": "^4.0.1",
+    "react-native-share": "^12.0.3",
     "react-native-svg": "^15.10.1",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       expo-router:
         specifier: ~4.0.15
         version: 4.0.15(72zdcgbazmkmqqgqvbbxkv7dry)
+      expo-sharing:
+        specifier: ~13.0.1
+        version: 13.0.1(expo@52.0.23(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))
       expo-splash-screen:
         specifier: ~0.29.18
         version: 0.29.18(expo@52.0.23(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))
@@ -124,6 +127,9 @@ importers:
       react-native-select-dropdown:
         specifier: ^4.0.1
         version: 4.0.1
+      react-native-share:
+        specifier: ^12.0.3
+        version: 12.0.3
       react-native-svg:
         specifier: ^15.10.1
         version: 15.10.1(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
@@ -5041,6 +5047,14 @@ packages:
       react-native-reanimated:
         optional: true
 
+  expo-sharing@13.0.1:
+    resolution:
+      {
+        integrity: sha512-qych3Nw65wlFcnzE/gRrsdtvmdV0uF4U4qVMZBJYPG90vYyWh2QM9rp1gVu0KWOBc7N8CC2dSVYn4/BXqJy6Xw==,
+      }
+    peerDependencies:
+      expo: "*"
+
   expo-splash-screen@0.29.18:
     resolution:
       {
@@ -8134,6 +8148,13 @@ packages:
       {
         integrity: sha512-t4se17kALFcPb9wMbxig5dS1BE3pWRC6HPuFlM0J2Y6yhB1GsLqboy6an6R9rML8pRuGIJIxL29cbwEvPQwKxQ==,
       }
+
+  react-native-share@12.0.3:
+    resolution:
+      {
+        integrity: sha512-Bg96AjouSbcpdlI/AzWXMBwpjyWcm4NvGr49mSF1cz8aw8E1sMXwpsHa6I841SJML8Im6sRN3aXnK+/QManrtQ==,
+      }
+    engines: { node: ">=16" }
 
   react-native-svg@15.10.1:
     resolution:
@@ -13821,6 +13842,10 @@ snapshots:
       - supports-color
       - typescript
 
+  expo-sharing@13.0.1(expo@52.0.23(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 52.0.23(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+
   expo-splash-screen@0.29.18(expo@52.0.23(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)):
     dependencies:
       "@expo/prebuild-config": 8.0.23
@@ -15964,6 +15989,8 @@ snapshots:
       warn-once: 0.1.1
 
   react-native-select-dropdown@4.0.1: {}
+
+  react-native-share@12.0.3: {}
 
   react-native-svg@15.10.1(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/src/app/connection/view-connection.tsx
+++ b/src/app/connection/view-connection.tsx
@@ -39,6 +39,7 @@ export default function ViewConnection() {
         area: true,
       },
     }),
+    [id],
   );
 
   const markAsPaid = async () => {

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -289,7 +289,7 @@ export default function Index() {
           onChange={setSelectedArea}
         />
         <Dropdown
-          data={["All", "Paid", "Unpaid"]}
+          data={["Paid", "Unpaid", "All"]}
           defaultValue={selectedStatus}
           onChange={setSelectedStatus}
         />

--- a/src/lib/file-sytem.ts
+++ b/src/lib/file-sytem.ts
@@ -1,4 +1,5 @@
 import * as FileSystem from "expo-file-system";
+import { File, Paths } from "expo-file-system/next";
 import { localStorage } from "./mmkv";
 import toast from "./toast";
 
@@ -6,7 +7,10 @@ import toast from "./toast";
  * Ask permission to access the media library
  * @returns {Promise<{granted: boolean, directoryUri: string}>}
  */
-export const askPermission = async () => {
+export const askPermission = async (): Promise<{
+  granted: boolean;
+  directoryUri: string;
+}> => {
   const uriFromLocalStorage = localStorage.getString("directoryUri");
   if (uriFromLocalStorage) {
     return { granted: true, directoryUri: uriFromLocalStorage };
@@ -43,4 +47,11 @@ export const saveFile = async (
   await FileSystem.writeAsStringAsync(fileUri, base64, {
     encoding: FileSystem.EncodingType.Base64,
   });
+};
+
+export const saveFileLocal = async (fileName: string, base64: string) => {
+  const file = new File(Paths.cache, fileName);
+  file.create();
+  file.write(base64);
+  return file.uri;
 };


### PR DESCRIPTION
For Android version 10 and lower the StorageAccessFramework doesn't work
in those case the app now invokes the system share api, so the user can
send it to an app that can save files to external storage.
